### PR TITLE
fixed linux transcoding

### DIFF
--- a/chromecast.js
+++ b/chromecast.js
@@ -87,7 +87,7 @@ var is_compatibile = function(file, callback){
 				obj.audio = 1;
 				obj.audio_transcode = "-acodec copy"
 				} else {
-				obj.audio_transcode = "-acodec aac -strict -2 -q:a 100"
+				obj.audio_transcode = "-acodec aac -q:a 100"
 				}
 			}
 		}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,6 @@
   { "express" : ">=3.4.8",
   	"dot" : ">=1.0.2",
   	"node-ffprobe" :  ">=1.2.2",
-  	"fluent-ffmpeg" : "git://github.com/schaermu/node-fluent-ffmpeg"
+  	"fluent-ffmpeg" : ">=1.5.2"
   }
 }

--- a/server.js
+++ b/server.js
@@ -73,8 +73,7 @@ app.get('/transcode', function(req, res) {
 		// use the 'flashvideo' preset (located in /lib/presets/flashvideo.js)
 		//.usingPreset('flashvideo')
 		.toFormat('matroska')
-		.addOptions( [data.audio_transcode, data.video_transcode] )
-		.withStrictExperimental()
+		.addOptions( ['-strict', 'experimental', data.audio_transcode, data.video_transcode] )
 		//.withVideoCodec('copy')
 		//.withAudioCodec('copy')
 		// save to stream


### PR DESCRIPTION
Please test this before merging. I only tested this on my machine and this could possibly break transcoding for other OSes.

The current audio transcoding option (libfaac) is not supported on at least my distro of Linux (Arch Linux), and most likely not supported on most other distros ([source 1](http://trac.ffmpeg.org/wiki/AACEncodingGuide), [source 2](https://bbs.archlinux.org/viewtopic.php?id=119535)). The audio transcoding option that works for Linux (aac) is experimental, so we also need to use the '-strict -2' flag. However, enabling the '-strict -2' flag with fluent-ffmpeg is only possible using the dev branch of fluent-ffmpeg (it was a recent change), so I changed the package.json file to pull fluent-ffmpeg from GitHub ([source](https://github.com/schaermu/node-fluent-ffmpeg/pull/160)).
