### PR TITLE
Tied fluent-ffmpeg version to 0.7. Fixes #22

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   { "express" : ">=3.4.8",
   	"dot" : ">=1.0.2",
   	"node-ffprobe" :  ">=1.2.2",
-  	"fluent-ffmpeg" : ">=1.5.2",
+  	"fluent-ffmpeg" : "~1.7",
 	"morgan" : ">=1.0.0"
   }
 }


### PR DESCRIPTION
With current software versions, HOTDOGSEAGULL doesn't quite work, as transcoding is broken. This can be fixed either by merging this, or changing how fluent-ffmpeg is used.
